### PR TITLE
Add support for authorization keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ client = Nano.client
 client = Nano::Client.new(host: 'mynanonode', port: 1234)
 ```
 
+If you're using [Nanode](https://www.nanode.co/) or some other public node, you can specify an Authorization header using `auth` too:
+
+```ruby
+
+```
+
 Then make a `call`, passing the action and data:
 
 ```ruby

--- a/lib/nano_rpc/client.rb
+++ b/lib/nano_rpc/client.rb
@@ -62,7 +62,7 @@ module Nano
 
     def headers
       headers = { 'Content-Type' => 'json' }
-      headers.merge!('Authorization' => auth) unless auth.nil?
+      headers['Authorization'] = auth unless auth.nil?
       headers
     end
 
@@ -77,7 +77,7 @@ module Nano
     end
 
     def url
-      if host.start_with?("http://") || host.start_with?("https://")
+      if host.start_with?('http://', 'https://')
         "#{host}:#{port}"
       else
         "http://#{host}:#{port}"

--- a/lib/nano_rpc/client.rb
+++ b/lib/nano_rpc/client.rb
@@ -61,11 +61,9 @@ module Nano
     end
 
     def headers
-      if @auth.nil?
-        {"Content-Type" => "json"}
-      else
-        {"Authorization" => @auth, "Content-Type" => "json"}
-      end
+      headers = { 'Content-Type' => 'json' }
+      headers.merge('Authorization' => auth) unless auth.nil?
+      headers
     end
 
     def rest_client_post(url, params)

--- a/lib/nano_rpc/client.rb
+++ b/lib/nano_rpc/client.rb
@@ -62,7 +62,7 @@ module Nano
 
     def headers
       headers = { 'Content-Type' => 'json' }
-      headers.merge('Authorization' => auth) unless auth.nil?
+      headers.merge!('Authorization' => auth) unless auth.nil?
       headers
     end
 

--- a/lib/nano_rpc/version.rb
+++ b/lib/nano_rpc/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module Nano
-  VERSION = '0.5.0'
+  VERSION = '0.6.0'
 end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -41,6 +41,22 @@ RSpec.describe Nano::Client do
     subject.call(action, params)
   end
 
+  it 'does not have an Authorization header when auth: is not specified' do
+    expect(subject.send :headers).to_not include('Authorization') 
+  end
+
+  context 'auth: is specified' do
+    let(:mock_key) { '00000000-0000-0000-0000-000000000000' }
+
+    before do
+      allow(subject).to receive(:auth).and_return(mock_key)
+    end
+
+    it 'includes an Authorization header' do
+      expect((subject.send :headers)['Authorization']).to eq(mock_key)
+    end
+  end
+
   context 'node connection failure' do
     before do
       allow(RestClient).to receive(:post).and_raise(Errno::ECONNREFUSED)

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -41,19 +41,12 @@ RSpec.describe Nano::Client do
     subject.call(action, params)
   end
 
-  it 'does not have an Authorization header when auth: is not specified' do
-    expect(subject.send :headers).to_not include('Authorization') 
-  end
+  context 'auth header' do
+    let(:auth_key) { 'exampleauthkey' }
+    let(:client_with_auth_key) { described_class.new(auth: auth_key) }
 
-  context 'auth: is specified' do
-    let(:mock_key) { '00000000-0000-0000-0000-000000000000' }
-
-    before do
-      allow(subject).to receive(:auth).and_return(mock_key)
-    end
-
-    it 'includes an Authorization header' do
-      expect((subject.send :headers)['Authorization']).to eq(mock_key)
+    it 'allows and exposes auth header configuration' do
+      expect(client_with_auth_key.auth).to eq(auth_key)
     end
   end
 


### PR DESCRIPTION
This PR adds support for an Authorization header on `Nano::Client`. This means that the library can work with the Nanode public node, which requires authorization to be done through an API key specified as the Authorization header.