### PR TITLE
Change fallaciously named wallet seed to id

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,12 +41,12 @@ Proxy objects are provided to ease interaction with the API by providing logical
 * [NanoRpc::Node](https://github.com/jcraigk/ruby_nano_rpc/wiki/NanoRpc::Node)
 * [NanoRpc::Wallet](https://github.com/jcraigk/ruby_nano_rpc/wiki/NanoRpc::Wallet)
 
-`Account`, `Accounts`, and `Wallet` each require a single parameter to be passed during initialization (`address`, `addresses`, and `seed`, respectively).  This parameter is persisted for subsequent calls.  All RPC methods are provided directly as methods.
+`Account`, `Accounts`, and `Wallet` each require a single parameter to be passed during initialization (`address`, `addresses`, and `id`, respectively).  This parameter is persisted for subsequent calls.  All RPC methods are provided directly as methods.
 
 ```ruby
 account = NanoRpc.node.account('xrb_1234') # Account address required
 accounts = NanoRpc.node.accounts(%w[xrb_1234 xrb_456]) # Array of account addresses required
-wallet = NanoRpc.node.wallet('3AF91AE') # Wallet seed required
+wallet = NanoRpc.node.wallet('3AF91AE') # Wallet id required
 ```
 
 You can call standard RPC methods on each object:

--- a/lib/nano_rpc/helpers/node_helper.rb
+++ b/lib/nano_rpc/helpers/node_helper.rb
@@ -54,8 +54,8 @@ module NanoRpc::NodeHelper
     available_supply.available
   end
 
-  def wallet(seed)
-    NanoRpc::Wallet.new(seed, node: self)
+  def wallet(id)
+    NanoRpc::Wallet.new(id, node: self)
   end
 
   def work_valid?(work:, hash:)

--- a/lib/nano_rpc/helpers/wallet_helper.rb
+++ b/lib/nano_rpc/helpers/wallet_helper.rb
@@ -87,7 +87,7 @@ module NanoRpc::WalletHelper
   end
 
   def move_accounts(to:, accounts:)
-    account_move(wallet: to, source: seed, accounts: accounts).moved == 1
+    account_move(wallet: to, source: id, accounts: accounts).moved == 1
   end
 
   def password_valid?(password:)

--- a/lib/nano_rpc/node.rb
+++ b/lib/nano_rpc/node.rb
@@ -133,7 +133,7 @@ class NanoRpc::Node
 
   def proxy_method(obj)
     if obj.is_a?(NanoRpc::Wallet)
-      :seed
+      :id
     elsif obj.is_a?(NanoRpc::Accounts)
       :addresses
     elsif obj.is_a?(NanoRpc::Account)

--- a/lib/nano_rpc/proxies/wallet.rb
+++ b/lib/nano_rpc/proxies/wallet.rb
@@ -3,24 +3,19 @@ class NanoRpc::Wallet
   include NanoRpc::Proxy
   include NanoRpc::WalletHelper
 
-  attr_reader :seed
+  attr_reader :id
 
-  def initialize(seed = nil, opts = {})
-    unless seed.is_a?(String)
+  def initialize(id = nil, opts = {})
+    unless id.is_a?(String)
       raise NanoRpc::MissingParameters,
-            'Missing argument: seed (str)'
+            'Missing argument: id (str)'
     end
 
-    @seed = seed
+    @id = id
     super(opts)
   end
 
-  # Hide secret seed on object inspection
-  def inspect
-    "#{inspect_prefix}, @node=#{@node.inspect}>"
-  end
-
-  proxy_params wallet: :seed
+  proxy_params wallet: :id
 
   proxy_method :account_create, optional: %i[work]
   proxy_method :accounts_create, required: %i[count], optional: %i[work]

--- a/lib/nano_rpc/proxy.rb
+++ b/lib/nano_rpc/proxy.rb
@@ -45,12 +45,7 @@ module NanoRpc::Proxy
 
   def execute_call
     result = node.call(@meth, @call_args)
-    handle_special_methods
     expose_nested_data(result)
-  end
-
-  def handle_special_methods
-    @seed = @call_args[:seed] if @meth == :wallet_change_seed
   end
 
   def base_params

--- a/lib/nano_rpc/version.rb
+++ b/lib/nano_rpc/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module NanoRpc
-  VERSION = '0.15.0'
+  VERSION = '0.16.0'
 end

--- a/nano_rpc.gemspec
+++ b/nano_rpc.gemspec
@@ -23,12 +23,12 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = %w[lib]
 
-  spec.add_development_dependency 'bundler', '~> 1.16.1'
+  spec.add_development_dependency 'bundler', '~> 1.16.3'
   spec.add_development_dependency 'codecov', '~> 0.1.10'
   spec.add_development_dependency 'pry', '~> 0.11.3'
   spec.add_development_dependency 'rake', '~> 12.3.1'
   spec.add_development_dependency 'rspec', '~> 3.7.0'
-  spec.add_development_dependency 'rubocop', '~> 0.56.0'
+  spec.add_development_dependency 'rubocop', '~> 0.58.2'
   spec.add_development_dependency 'simplecov', '~> 0.16.1'
 
   spec.add_runtime_dependency 'hashie', '~> 3.5', '>= 3.5.7'

--- a/spec/lib/nano_rpc/helpers/account_helper_spec.rb
+++ b/spec/lib/nano_rpc/helpers/account_helper_spec.rb
@@ -8,27 +8,27 @@ end
 RSpec.describe AccountHelperExample do
   subject { NanoRpc::Account.new('abc') }
   let(:history_data) do
-    [{ 'hash' => seed1 }, { 'hash' => seed1 }]
+    [{ 'hash' => wallet_id1 }, { 'hash' => wallet_id1 }]
   end
   let(:info_data) do
-    { 'frontier' => addr1, 'open_block' => seed1 }
+    { 'frontier' => addr1, 'open_block' => wallet_id1 }
   end
-  let(:account_move_params) { { from: seed1, to: 'DEF' } }
+  let(:account_move_params) { { from: wallet_id1, to: 'DEF' } }
   let(:account_move_opts) do
-    { wallet: 'DEF', source: seed1, accounts: [addr1] }
+    { wallet: 'DEF', source: wallet_id1, accounts: [addr1] }
   end
   let(:addr1) { 'nano_address1' }
   let(:addr2) { 'nano_address2' }
-  let(:seed1) { 'A4C1EF' }
-  let(:seed2) { 'F9CD82' }
-  let(:seeds) { [seed1, seed2] }
+  let(:wallet_id1) { 'A4C1EF' }
+  let(:wallet_id2) { 'F9CD82' }
+  let(:wallet_ids) { [wallet_id1, wallet_id2] }
   let(:work1) { '000000' }
   let(:pending_blocks_data) { { count: 1, threshold: '1000', source: true } }
   let(:balance_data) { { 'balance' => '100', 'pending' => '5' } }
-  let(:wallet_work_params) { { wallet: seed1, work: work1 } }
-  let(:rep_set_params) { { wallet: seed1, representative: addr1 } }
-  let(:wallet) { NanoRpc::Wallet.new(seed1) }
-  let(:wallet2) { NanoRpc::Wallet.new(seed2) }
+  let(:wallet_work_params) { { wallet: wallet_id1, work: work1 } }
+  let(:rep_set_params) { { wallet: wallet_id1, representative: addr1 } }
+  let(:wallet) { NanoRpc::Wallet.new(wallet_id1) }
+  let(:wallet2) { NanoRpc::Wallet.new(wallet_id2) }
 
   it 'provides #balance' do
     allow(subject).to receive(:account_balance).and_return(
@@ -62,9 +62,9 @@ RSpec.describe AccountHelperExample do
 
   it 'provides #key' do
     allow(subject).to(
-      receive(:account_key).and_return(NanoRpc::Response.new('key' => seed1))
+      receive(:account_key).and_return(NanoRpc::Response.new('key' => wallet_id1))
     )
-    expect(subject.key).to eq(seed1)
+    expect(subject.key).to eq(wallet_id1)
   end
 
   it 'provides #move' do
@@ -99,19 +99,19 @@ RSpec.describe AccountHelperExample do
     allow(subject).to(
       receive(:pending)
         .with(pending_blocks_data)
-        .and_return(NanoRpc::Response.new('blocks' => seeds))
+        .and_return(NanoRpc::Response.new('blocks' => wallet_ids))
     )
-    expect(subject.pending_blocks(pending_blocks_data)).to eq(seeds)
-    expect(subject.blocks_pending(pending_blocks_data)).to eq(seeds)
+    expect(subject.pending_blocks(pending_blocks_data)).to eq(wallet_ids)
+    expect(subject.blocks_pending(pending_blocks_data)).to eq(wallet_ids)
   end
 
   it 'provides #remove' do
     allow(subject).to(
       receive(:account_remove)
-        .with(wallet: seed1)
+        .with(wallet: wallet_id1)
         .and_return(NanoRpc::Response.new('removed' => '1'))
     )
-    expect(subject.remove(wallet: seed1)).to eq(true)
+    expect(subject.remove(wallet: wallet_id1)).to eq(true)
   end
 
   it 'provides #representative' do

--- a/spec/lib/nano_rpc/helpers/accounts_helper_spec.rb
+++ b/spec/lib/nano_rpc/helpers/accounts_helper_spec.rb
@@ -11,8 +11,8 @@ RSpec.describe AccountsHelperExample do
   let(:addr2) { 'nano_address2' }
   let(:block1) { '9FE23A' }
   let(:block2) { '1ACFF4' }
-  let(:seed1) { 'ABCDEF' }
-  let(:seed2) { '298EDA' }
+  let(:wallet_id1) { 'ABCDEF' }
+  let(:wallet_id2) { '298EDA' }
   let(:balances_data) do
     {
       'balances' => {
@@ -50,9 +50,9 @@ RSpec.describe AccountsHelperExample do
 
   it 'provides #move' do
     allow(subject).to receive(:account_move)
-      .with(wallet: seed2, source: seed1)
+      .with(wallet: wallet_id2, source: wallet_id1)
       .and_return(NanoRpc::Response.new('moved' => '1'))
-    expect(subject.move(from: seed1, to: seed2)).to eq(true)
+    expect(subject.move(from: wallet_id1, to: wallet_id2)).to eq(true)
   end
 
   it 'provides #pending and #pending_blocks' do

--- a/spec/lib/nano_rpc/helpers/node_helper_spec.rb
+++ b/spec/lib/nano_rpc/helpers/node_helper_spec.rb
@@ -17,15 +17,15 @@ RSpec.describe NodeHelperExample do
   let(:pending_hash) { '000BDE' }
   let(:work_params) { { work: '2def', hash: '000DEF' } }
   let(:addr1) { 'nano_address1' }
-  let(:seed1) { 'A0BF3C' }
+  let(:wallet_id1) { 'A0BF3C' }
   let(:amount_param) { { amount: 1 } }
   let(:pending_hash_param) { { hash: pending_hash } }
   let(:addresses) { %w[abc def] }
 
   context 'proxy object wrappers' do
     it 'provides #wallet' do
-      expect(NanoRpc::Wallet).to receive(:new).with(seed1, node: subject)
-      subject.wallet(seed1)
+      expect(NanoRpc::Wallet).to receive(:new).with(wallet_id1, node: subject)
+      subject.wallet(wallet_id1)
     end
 
     it 'provides #account' do
@@ -57,11 +57,11 @@ RSpec.describe NodeHelperExample do
 
   it 'provides #create_wallet' do
     allow(subject).to receive(:wallet_create).and_return(
-      NanoRpc::Response.new('wallet' => seed1)
+      NanoRpc::Response.new('wallet' => wallet_id1)
     )
     wallet = subject.create_wallet
     expect(wallet.class).to eq(NanoRpc::Wallet)
-    expect(wallet.seed).to eq(seed1)
+    expect(wallet.id).to eq(wallet_id1)
   end
 
   it 'provides #num_frontiers' do

--- a/spec/lib/nano_rpc/helpers/wallet_helper_spec.rb
+++ b/spec/lib/nano_rpc/helpers/wallet_helper_spec.rb
@@ -25,13 +25,14 @@ RSpec.describe WalletHelperExample do
       }
     }
   end
-  let(:seed1) { 'CB3004' }
+  let(:wallet_id1) { 'CB3004' }
+  let(:seed) { 'ABCDEF' }
   let(:wallet_data) { { 'some_key' => 1 } }
   let(:block1) { '000D1BA' }
   let(:block2) { 'F2B3809' }
-  let(:seed1) { 'A4C1EF' }
-  let(:seed2) { 'F9CD82' }
-  let(:pending_blocks_params) { { count: 2, threshold: 10, source: seed1 } }
+  let(:wallet_id1) { 'A4C1EF' }
+  let(:wallet_id2) { 'F9CD82' }
+  let(:pending_blocks_params) { { count: 2, threshold: 10, source: wallet_id1 } }
   let(:work1) { '000000' }
   let(:account_param) { { account: addr1 } }
   let(:account_work_params) { { account: addr1, work: work1 } }
@@ -79,9 +80,9 @@ RSpec.describe WalletHelperExample do
     allow(subject).to(
       receive(:wallet_add)
         .with(add_account_params)
-        .and_return(NanoRpc::Response.new('account' => seed1))
+        .and_return(NanoRpc::Response.new('account' => wallet_id1))
     )
-    expect(subject.add_key(add_account_params)).to eq(seed1)
+    expect(subject.add_key(add_account_params)).to eq(wallet_id1)
   end
 
   it 'provides #add_watch' do
@@ -131,8 +132,7 @@ RSpec.describe WalletHelperExample do
     allow_any_instance_of(NanoRpc::Node).to receive(:call).and_return(
       NanoRpc::Response.new('success' => '')
     )
-    expect(subject.change_seed(new_seed: seed1)).to eq(true)
-    expect(subject.seed).to eq(seed1)
+    expect(subject.change_seed(new_seed: seed)).to eq(true)
   end
 
   it 'provides #contains?' do
@@ -227,13 +227,13 @@ RSpec.describe WalletHelperExample do
   end
 
   it 'provides #move_accounts' do
-    allow(subject).to receive(:seed).and_return(seed1)
+    allow(subject).to receive(:id).and_return(wallet_id1)
     allow(subject).to(
       receive(:account_move)
-        .with(wallet: seed2, source: seed1, accounts: addresses)
+        .with(wallet: wallet_id2, source: wallet_id1, accounts: addresses)
         .and_return(NanoRpc::Response.new('moved' => '1'))
     )
-    expect(subject.move_accounts(to: seed2, accounts: addresses)).to eq(true)
+    expect(subject.move_accounts(to: wallet_id2, accounts: addresses)).to eq(true)
   end
 
   it 'provides #password_valid?' do

--- a/spec/lib/nano_rpc/node_spec.rb
+++ b/spec/lib/nano_rpc/node_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe NanoRpc::Node do
     { error: error_msg }.to_json
   end
   let(:error_msg) { 'Bad account number' }
-  let(:seed1) { 'ABCDEF' }
+  let(:wallet_id) { 'ABCDEF' }
   let(:addr1) { 'nano_address1' }
   let(:addr2) { 'nano_address2' }
   let(:addresses) { [addr1, addr2] }
@@ -252,11 +252,11 @@ RSpec.describe NanoRpc::Node do
   end
 
   context 'proxy objects' do
-    it 'pulls #seed from NanoRpc::Wallet' do
+    it 'pulls #id from NanoRpc::Wallet' do
       expect(subject).to(
-        receive(:rpc_post).with(action: action, wallet: seed1)
+        receive(:rpc_post).with(action: action, wallet: wallet_id)
       )
-      subject.call(action, wallet: NanoRpc::Wallet.new(seed1))
+      subject.call(action, wallet: NanoRpc::Wallet.new(wallet_id))
     end
 
     it 'pulls #addresses from NanoRpc::Accounts' do

--- a/spec/lib/nano_rpc/proxies/wallet_spec.rb
+++ b/spec/lib/nano_rpc/proxies/wallet_spec.rb
@@ -2,8 +2,8 @@
 require 'spec_helper'
 
 RSpec.describe NanoRpc::Wallet do
-  subject { described_class.new(seed) }
-  let(:seed) { 'E929FBC3' }
+  subject { described_class.new(wallet_id) }
+  let(:wallet_id) { 'E929FBC3' }
   let(:expected_proxy_methods) do
     %i[
       account_create
@@ -39,7 +39,7 @@ RSpec.describe NanoRpc::Wallet do
       work_set
     ]
   end
-  let(:expected_proxy_params) { { wallet: :seed } }
+  let(:expected_proxy_params) { { wallet: :id } }
 
   it 'defines expected proxy params and methods' do
     expect(described_class.proxy_param_def).to eq(expected_proxy_params)
@@ -48,30 +48,11 @@ RSpec.describe NanoRpc::Wallet do
 
   it 'raises MissingParameters unless initialized with string' do
     expect { described_class.new }.to raise_error(
-      NanoRpc::MissingParameters, 'Missing argument: seed (str)'
+      NanoRpc::MissingParameters, 'Missing argument: id (str)'
     )
   end
 
-  it 'assigns seed on initialization' do
-    expect(subject.seed).to eq(seed)
-  end
-
-  it 'obscures seed in #inspect output' do
-    expect(subject.inspect).to_not include('@seed')
-  end
-
-  context 'when changing the remote seed' do
-    let(:new_seed) { 'abcdef' }
-
-    before do
-      allow_any_instance_of(NanoRpc::Node).to receive(:call).and_return(
-        NanoRpc::Response.new('success' => '')
-      )
-    end
-
-    it 'changes local @seed when changing remote seed' do
-      subject.wallet_change_seed(seed: new_seed)
-      expect(subject.seed).to eq(new_seed)
-    end
+  it 'assigns id on initialization' do
+    expect(subject.id).to eq(wallet_id)
   end
 end


### PR DESCRIPTION
What I thought were wallet seeds are really just ids, so renaming is in order as well as some specialization around changing the seed.  This makes a lot more sense now :)