### PR TITLE
Release 15 updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,10 @@ Nano RPC is a Ruby wrapper for making Remote Procedure Calls against Nano digita
 
 To run a Nano node locally, see [Nano Docker Docs](https://github.com/clemahieu/raiblocks/wiki/Docker-node).
 
-**This gem is compliant with Nano release v14.2.**
+| Gem version | Nanocurrency version |
+|-------------|----------------------|
+| 0.20        | >= 15.0              |
+| 0.19        | >= 14.2, < 15.0      |
 
 ## Installation
 

--- a/lib/nano_rpc/helpers/accounts_helper.rb
+++ b/lib/nano_rpc/helpers/accounts_helper.rb
@@ -27,11 +27,12 @@ module NanoRpc::AccountsHelper
     account_move(source: from, wallet: to).moved == 1
   end
 
-  def pending(count:, threshold: nil, source: nil)
+  def pending(count:, threshold: nil, source: nil, include_active: nil)
     accounts_pending(
       count: count,
       threshold: threshold,
-      source: source
+      source: source,
+      include_active: include_active
     ).blocks
   end
   alias pending_blocks pending

--- a/lib/nano_rpc/helpers/wallet_helper.rb
+++ b/lib/nano_rpc/helpers/wallet_helper.rb
@@ -20,7 +20,7 @@ module NanoRpc::WalletHelper
   end
 
   def balance
-    wallet_balance_total.balance
+    wallet_info.balance
   end
 
   def balances(threshold: nil)
@@ -95,7 +95,7 @@ module NanoRpc::WalletHelper
   end
 
   def pending_balance
-    wallet_balance_total.pending
+    wallet_info.pending
   end
   alias balance_pending pending_balance
 

--- a/lib/nano_rpc/helpers/wallet_helper.rb
+++ b/lib/nano_rpc/helpers/wallet_helper.rb
@@ -108,11 +108,12 @@ module NanoRpc::WalletHelper
   end
   alias balances_pending pending_balances
 
-  def pending_blocks(count:, threshold: nil, source: nil)
+  def pending_blocks(count:, threshold: nil, source: nil, include_active: nil)
     wallet_pending(
       count: count,
       threshold: threshold,
-      source: source
+      source: source,
+      include_active: include_active
     ).blocks
   end
   alias blocks_pending pending_blocks

--- a/lib/nano_rpc/methods/account_methods.rb
+++ b/lib/nano_rpc/methods/account_methods.rb
@@ -43,7 +43,7 @@ module NanoRpc::AccountMethods
       },
       pending: {
         required: %i[count],
-        optional: %i[threshold exists source]
+        optional: %i[threshold exists source include_active]
       },
       receive: {
         required: %i[wallet block],

--- a/lib/nano_rpc/methods/accounts_methods.rb
+++ b/lib/nano_rpc/methods/accounts_methods.rb
@@ -17,7 +17,7 @@ module NanoRpc::AccountsMethods
       accounts_frontiers: {},
       accounts_pending: {
         required: %i[count],
-        optional: %i[threshold source]
+        optional: %i[threshold source include_active]
       }
     }
   end

--- a/lib/nano_rpc/methods/wallet_methods.rb
+++ b/lib/nano_rpc/methods/wallet_methods.rb
@@ -62,7 +62,7 @@ module NanoRpc::WalletMethods
       wallet_locked: {},
       wallet_pending: {
         required: %i[count],
-        optional: %i[threshold source]
+        optional: %i[threshold source include_active]
       },
       wallet_representative: {},
       wallet_representative_set: {

--- a/lib/nano_rpc/methods/wallet_methods.rb
+++ b/lib/nano_rpc/methods/wallet_methods.rb
@@ -45,7 +45,6 @@ module NanoRpc::WalletMethods
       wallet_add_watch: {
         required: %i[accounts]
       },
-      wallet_balance_total: {},
       wallet_balances: {
         optional: %i[threshold]
       },
@@ -58,6 +57,7 @@ module NanoRpc::WalletMethods
       wallet_destroy: {},
       wallet_export: {},
       wallet_frontiers: {},
+      wallet_info: {},
       wallet_ledger: {},
       wallet_locked: {},
       wallet_pending: {

--- a/lib/nano_rpc/version.rb
+++ b/lib/nano_rpc/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module NanoRpc
-  VERSION = '0.19.0'
+  VERSION = '0.20.0'
 end

--- a/spec/lib/nano_rpc/helpers/accounts_helper_spec.rb
+++ b/spec/lib/nano_rpc/helpers/accounts_helper_spec.rb
@@ -24,7 +24,14 @@ RSpec.describe AccountsHelperExample do
   let(:frontiers_data) { { 'frontiers' => frontiers_hash } }
   let(:frontiers_hash) { { addr1 => block1, addr2 => block2 } }
   let(:pending_hash) { { addr1 => [block1], addr2 => [block2] } }
-  let(:pending_params) { { count: 1, threshold: 100, source: true } }
+  let(:pending_params) do
+    {
+      count: 1,
+      threshold: 100,
+      source: true,
+      include_active: true
+    }
+  end
 
   it 'provides #balances' do
     allow(subject).to receive(:accounts_balances).and_return(

--- a/spec/lib/nano_rpc/helpers/wallet_helper_spec.rb
+++ b/spec/lib/nano_rpc/helpers/wallet_helper_spec.rb
@@ -107,7 +107,7 @@ RSpec.describe WalletHelperExample do
 
   it 'provides #balance' do
     allow(subject).to(
-      receive(:wallet_balance_total)
+      receive(:wallet_info)
         .and_return(NanoRpc::Response.new(balance_data))
     )
     expect(subject.balance).to eq(100)
@@ -260,7 +260,7 @@ RSpec.describe WalletHelperExample do
 
   it 'provides #pending_balance and #balance_pending' do
     allow(subject).to(
-      receive(:wallet_balance_total)
+      receive(:wallet_info)
         .and_return(NanoRpc::Response.new(balance_data))
     )
     expect(subject.pending_balance).to eq(5)

--- a/spec/lib/nano_rpc/helpers/wallet_helper_spec.rb
+++ b/spec/lib/nano_rpc/helpers/wallet_helper_spec.rb
@@ -32,8 +32,13 @@ RSpec.describe WalletHelperExample do
   let(:block2) { 'F2B3809' }
   let(:wallet_id1) { 'A4C1EF' }
   let(:wallet_id2) { 'F9CD82' }
-  let(:pending_blocks_params) do
-    { count: 2, threshold: 10, source: wallet_id1 }
+  let(:wallet_pending_params) do
+    {
+      count: 2,
+      threshold: 10,
+      source: wallet_id1,
+      include_active: true
+    }
   end
   let(:work1) { '000000' }
   let(:account_param) { { account: addr1 } }
@@ -284,14 +289,14 @@ RSpec.describe WalletHelperExample do
   it 'provides #pending_blocks and #blocks_pending' do
     allow(subject).to(
       receive(:wallet_pending)
-        .with(pending_blocks_params)
+        .with(wallet_pending_params)
         .and_return(NanoRpc::Response.new('blocks' => pending_blocks_data))
     )
     expect(
-      subject.pending_blocks(pending_blocks_params)
+      subject.pending_blocks(wallet_pending_params)
     ).to eq(pending_blocks_data)
     expect(
-      subject.blocks_pending(pending_blocks_params)
+      subject.blocks_pending(wallet_pending_params)
     ).to eq(pending_blocks_data)
   end
 

--- a/spec/lib/nano_rpc/proxies/wallet_spec.rb
+++ b/spec/lib/nano_rpc/proxies/wallet_spec.rb
@@ -21,13 +21,13 @@ RSpec.describe NanoRpc::Wallet do
       send
       wallet_add
       wallet_add_watch
-      wallet_balance_total
       wallet_balances
       wallet_change_seed
       wallet_contains
       wallet_destroy
       wallet_export
       wallet_frontiers
+      wallet_info
       wallet_ledger
       wallet_locked
       wallet_pending


### PR DESCRIPTION
Updates for Nanocurrency release v15.0 (https://github.com/nanocurrency/raiblocks/releases/tag/V15.0).