### PR TITLE
Nano v17

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,3 +1,3 @@
---format documentation
+--format progress
 --color
 --require spec_helper

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,10 @@
+require: rubocop-rspec
+
 AllCops:
   TargetRubyVersion: 2.5.3
   Exclude:
     - bin/*
+    - nano_rpc.gemspec
   DisplayCopNames: true
 Metrics/BlockLength:
   Exclude:
@@ -13,7 +16,7 @@ Metrics/ClassLength:
 Style/ClassAndModuleChildren:
   Enabled: false
 Style/EmptyMethod:
-  EnforcedStyle: expanded
+  Enabled: false
 Layout/EmptyLineAfterGuardClause:
   Enabled: false
 Layout/EmptyLineAfterMagicComment:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.5.0
+  TargetRubyVersion: 2.5.3
   Exclude:
     - bin/*
   DisplayCopNames: true
@@ -11,7 +11,7 @@ Metrics/ModuleLength:
 Metrics/ClassLength:
   Max: 200
 Style/ClassAndModuleChildren:
-  EnforcedStyle: compact
+  Enabled: false
 Style/EmptyMethod:
   EnforcedStyle: expanded
 Layout/EmptyLineAfterGuardClause:

--- a/README.md
+++ b/README.md
@@ -12,8 +12,9 @@ To run a Nano node locally, see [Nano Docker Docs](https://github.com/clemahieu/
 
 | Gem version | Nanocurrency version |
 |-------------|----------------------|
-| 0.22        | >= 16.0              |
-| 0.20        | >= 15.0              |
+| 0.24        | >= 17.0              |
+| 0.23        | >= 16.0, < 17.0      |
+| 0.20        | >= 15.0, < 16.0      |
 | 0.19        | >= 14.2, < 15.0      |
 
 ## Installation

--- a/lib/nano_rpc/methods/node_methods.rb
+++ b/lib/nano_rpc/methods/node_methods.rb
@@ -49,7 +49,7 @@ module NanoRpc::NodeMethods
       },
       confirmation_quorum: {
         optional: %i[peer_details]
-      }
+      },
       deterministic_key: {
         required: %i[seed index]
       },

--- a/lib/nano_rpc/methods/node_methods.rb
+++ b/lib/nano_rpc/methods/node_methods.rb
@@ -33,10 +33,23 @@ module NanoRpc::NodeMethods
         required: %i[address port]
       },
       bootstrap_any: {},
+      bootstrap_lazy: {
+        required: %i[hash],
+        optional: %i[force]
+      },
+      bootstrap_status: {},
       chain: {
         required: %i[block count]
       },
+      confirmation_active: {},
       confirmation_history: {},
+      confirmation_info: {
+        required: %i[root],
+        optional: %i[contents representatives]
+      },
+      confirmation_quorum: {
+        optional: %i[peer_details]
+      }
       deterministic_key: {
         required: %i[seed index]
       },
@@ -63,6 +76,8 @@ module NanoRpc::NodeMethods
       mrai_to_raw: {
         required: %i[amount]
       },
+      node_id: {},
+      node_id_delete: {},
       payment_wait: {
         required: %i[account amount timeout]
       },

--- a/lib/nano_rpc/version.rb
+++ b/lib/nano_rpc/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module NanoRpc
-  VERSION = '0.23.0'
+  VERSION = '0.24.0'
 end

--- a/nano_rpc.gemspec
+++ b/nano_rpc.gemspec
@@ -23,12 +23,12 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = %w[lib]
 
-  spec.add_development_dependency 'bundler', '~> 1.16.5'
-  spec.add_development_dependency 'codecov', '~> 0.1.10'
-  spec.add_development_dependency 'pry', '~> 0.11.3'
-  spec.add_development_dependency 'rake', '~> 12.3.1'
+  spec.add_development_dependency 'bundler', '~> 1.17.2'
+  spec.add_development_dependency 'codecov', '~> 0.1.14'
+  spec.add_development_dependency 'pry', '~> 0.12.2'
+  spec.add_development_dependency 'rake', '~> 12.3.2'
   spec.add_development_dependency 'rspec', '~> 3.8.0'
-  spec.add_development_dependency 'rubocop', '~> 0.59.2'
+  spec.add_development_dependency 'rubocop', '~> 0.61.1'
   spec.add_development_dependency 'simplecov', '~> 0.16.1'
   spec.add_development_dependency 'simplecov-rcov', '~> 0.2.3'
 

--- a/nano_rpc.gemspec
+++ b/nano_rpc.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 12.3.2'
   spec.add_development_dependency 'rspec', '~> 3.8.0'
   spec.add_development_dependency 'rubocop', '~> 0.61.1'
+  spec.add_development_dependency 'rubocop-rspec', '~> 1.30.1'
   spec.add_development_dependency 'simplecov', '~> 0.16.1'
   spec.add_development_dependency 'simplecov-rcov', '~> 0.2.3'
 

--- a/spec/lib/nano_rpc/node_spec.rb
+++ b/spec/lib/nano_rpc/node_spec.rb
@@ -34,8 +34,13 @@ RSpec.describe NanoRpc::Node do
         blocks_info
         bootstrap
         bootstrap_any
+        bootstrap_lazy
+        bootstrap_status
         chain
+        confirmation_active
         confirmation_history
+        confirmation_info
+        confirmation_quorum
         deterministic_key
         frontier_count
         history
@@ -46,6 +51,8 @@ RSpec.describe NanoRpc::Node do
         krai_to_raw
         mrai_from_raw
         mrai_to_raw
+        node_id
+        node_id_delete
         payment_wait
         peers
         pending_exists


### PR DESCRIPTION
* Add Node v17 RPC commands
* Update dev dependencies
* Minor config tweaks
* Add `rubocop-rspec` (not yet compliant)