### PR TITLE
Add v19 and previously omitted methods

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,24 @@
 require: rubocop-rspec
+
+AllCops:
+  TargetRubyVersion: 2.6.3
+  Exclude:
+    - bin/*
+    - nano_rpc.gemspec
+  DisplayCopNames: true
+Documentation:
+  Enabled: false
+Layout/EmptyLineAfterGuardClause:
+  Enabled: false
+Layout/EmptyLineAfterMagicComment:
+  Enabled: false
+Metrics/BlockLength:
+  Exclude:
+    - spec/**/*
+Metrics/ClassLength:
+  Max: 200
+Metrics/ModuleLength:
+  Max: 200
 RSpec/ExampleLength:
   Max: 8
 RSpec/MultipleExpectations:
@@ -7,27 +27,9 @@ RSpec/NestedGroups:
   Max: 4
 RSpec/SubjectStub:
   Enabled: false
-
-AllCops:
-  TargetRubyVersion: 2.6.1
-  Exclude:
-    - bin/*
-    - nano_rpc.gemspec
-  DisplayCopNames: true
-Metrics/BlockLength:
-  Exclude:
-    - spec/**/*
-Metrics/ModuleLength:
-  Max: 200
-Metrics/ClassLength:
-  Max: 200
 Style/ClassAndModuleChildren:
   Enabled: false
 Style/EmptyMethod:
   Enabled: false
-Layout/EmptyLineAfterGuardClause:
-  Enabled: false
-Layout/EmptyLineAfterMagicComment:
-  Enabled: false
-Documentation:
-  Enabled: false
+
+

--- a/lib/nano_rpc/methods/account_methods.rb
+++ b/lib/nano_rpc/methods/account_methods.rb
@@ -46,7 +46,7 @@ module NanoRpc::AccountMethods
       },
       pending: {
         required: %i[count],
-        optional: %i[threshold exists source include_active]
+        optional: %i[threshold exists source include_active sorting include_only_confirmed]
       },
       receive: {
         required: %i[wallet block],

--- a/lib/nano_rpc/methods/account_methods.rb
+++ b/lib/nano_rpc/methods/account_methods.rb
@@ -17,7 +17,9 @@ module NanoRpc::AccountMethods
         required: %i[count],
         optional: %i[raw head]
       },
-      account_info: {},
+      account_info: {
+        optional: %i[representative weight pending]
+      },
       account_key: {},
       account_move: {
         required: %i[wallet source accounts]

--- a/lib/nano_rpc/methods/account_methods.rb
+++ b/lib/nano_rpc/methods/account_methods.rb
@@ -46,7 +46,10 @@ module NanoRpc::AccountMethods
       },
       pending: {
         required: %i[count],
-        optional: %i[threshold exists source include_active sorting include_only_confirmed]
+        optional: %i[
+          threshold exists source include_active
+          sorting include_only_confirmed
+        ]
       },
       receive: {
         required: %i[wallet block],

--- a/lib/nano_rpc/methods/accounts_methods.rb
+++ b/lib/nano_rpc/methods/accounts_methods.rb
@@ -17,7 +17,10 @@ module NanoRpc::AccountsMethods
       accounts_frontiers: {},
       accounts_pending: {
         required: %i[count],
-        optional: %i[threshold source include_active sorting include_only_confirmed]
+        optional: %i[
+          threshold source include_active
+          sorting include_only_confirmed
+        ]
       }
     }
   end

--- a/lib/nano_rpc/methods/accounts_methods.rb
+++ b/lib/nano_rpc/methods/accounts_methods.rb
@@ -17,7 +17,7 @@ module NanoRpc::AccountsMethods
       accounts_frontiers: {},
       accounts_pending: {
         required: %i[count],
-        optional: %i[threshold source include_active]
+        optional: %i[threshold source include_active sorting include_only_confirmed]
       }
     }
   end

--- a/lib/nano_rpc/methods/node_methods.rb
+++ b/lib/nano_rpc/methods/node_methods.rb
@@ -20,14 +20,21 @@ module NanoRpc::NodeMethods
       block_count_type: {},
       block_create: {
         required: %i[type key representative source],
-        optional: %i[work]
+        optional: %i[work json_block]
+      },
+      block_hash: {
+        optional: %i[json_block]
+      },
+      block_info: {
+        required: %i[hash],
+        optional: %i[json_block]
       },
       blocks: {
         required: %i[hashes]
       },
       blocks_info: {
         required: %i[hashes],
-        optional: %i[pending source balance]
+        optional: %i[pending source balance json_block]
       },
       bootstrap: {
         required: %i[address port]
@@ -42,11 +49,14 @@ module NanoRpc::NodeMethods
         required: %i[block count],
         optional: %i[offset reverse]
       },
-      confirmation_active: {},
+      confirmation_active: {
+        optional: %i[announcements]
+      },
+      confirmation_height_currently_processing: {},
       confirmation_history: {},
       confirmation_info: {
         required: %i[root],
-        optional: %i[contents representatives]
+        optional: %i[contents representatives json_block]
       },
       confirmation_quorum: {
         optional: %i[peer_details]
@@ -86,11 +96,12 @@ module NanoRpc::NodeMethods
         optional: %i[peer_details]
       },
       pending_exists: {
-        required: %i[hash]
+        required: %i[hash],
+        optional: %i[include_active include_only_confirmed]
       },
       process: {
         required: %i[block],
-        optional: %i[force subtype]
+        optional: %i[force subtype json_block]
       },
       rai_from_raw: {
         required: %i[amount]
@@ -113,7 +124,7 @@ module NanoRpc::NodeMethods
       },
       search_pending_all: {},
       sign: {
-        optional: %i[account hash key wallet]
+        optional: %i[account hash key wallet json_block]
       },
       stats: {
         required: %i[type]
@@ -129,10 +140,15 @@ module NanoRpc::NodeMethods
       },
       unchecked_clear: {},
       unchecked_get: {
-        required: %i[hash]
+        required: %i[hash],
+        optional: %i[json_block]
       },
       unchecked_keys: {
-        required: %i[key count]
+        required: %i[key count],
+        optional: %i[json_block]
+      },
+      unopened: {
+        optional: %i[account count]
       },
       uptime: {},
       version: {},

--- a/lib/nano_rpc/methods/node_methods.rb
+++ b/lib/nano_rpc/methods/node_methods.rb
@@ -6,6 +6,7 @@ module NanoRpc::NodeMethods
 
   def proxy_methods # rubocop:disable Metrics/MethodLength
     {
+      active_difficulty: {},
       available_supply: {},
       block: {
         required: %i[hash]

--- a/lib/nano_rpc/proxy.rb
+++ b/lib/nano_rpc/proxy.rb
@@ -3,7 +3,7 @@ module NanoRpc::Proxy
   attr_reader :node
 
   def initialize(opts = {})
-    @node = opts[:node] || NanoRpc.node
+    @node = @node || opts[:node] || NanoRpc.node
     proxy_methods.each { |meth, _| define_proxy_method(meth) }
   end
 

--- a/lib/nano_rpc/proxy.rb
+++ b/lib/nano_rpc/proxy.rb
@@ -3,7 +3,7 @@ module NanoRpc::Proxy
   attr_reader :node
 
   def initialize(opts = {})
-    @node ||= opts[:node] || NanoRpc.node
+    @node = opts[:node] || NanoRpc.node
     proxy_methods.each { |meth, _| define_proxy_method(meth) }
   end
 

--- a/lib/nano_rpc/version.rb
+++ b/lib/nano_rpc/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module NanoRpc
-  VERSION = '0.25.0'
+  VERSION = '0.26.0'
 end

--- a/nano_rpc.gemspec
+++ b/nano_rpc.gemspec
@@ -34,5 +34,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'simplecov-rcov', '~> 0.2.3'
 
   spec.add_runtime_dependency 'hashie', '~> 3.6', '>= 3.6.0'
-  spec.add_runtime_dependency 'http', '~> 4.0', '>= 4.0.5'
+  spec.add_runtime_dependency 'http', '~> 4.1', '>= 4.0.5'
 end

--- a/nano_rpc.gemspec
+++ b/nano_rpc.gemspec
@@ -28,11 +28,11 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'pry', '~> 0.12.2'
   spec.add_development_dependency 'rake', '~> 12.3.2'
   spec.add_development_dependency 'rspec', '~> 3.8.0'
-  spec.add_development_dependency 'rubocop', '~> 0.71.0'
-  spec.add_development_dependency 'rubocop-rspec', '~> 1.30.1'
-  spec.add_development_dependency 'simplecov', '~> 0.16.1'
+  spec.add_development_dependency 'rubocop', '~> 0.72.0'
+  spec.add_development_dependency 'rubocop-rspec', '~> 1.33.0'
+  spec.add_development_dependency 'simplecov', '~> 0.17.0'
   spec.add_development_dependency 'simplecov-rcov', '~> 0.2.3'
 
   spec.add_runtime_dependency 'hashie', '~> 3.6', '>= 3.6.0'
-  spec.add_runtime_dependency 'http', '~> 4.1', '>= 4.0.5'
+  spec.add_runtime_dependency 'http', '~> 4.1.1', '>= 4.0.5'
 end

--- a/nano_rpc.gemspec
+++ b/nano_rpc.gemspec
@@ -23,12 +23,12 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = %w[lib]
 
-  spec.add_development_dependency 'bundler', '~> 1.17.2'
+  spec.add_development_dependency 'bundler', '~> 2.0.2'
   spec.add_development_dependency 'codecov', '~> 0.1.14'
   spec.add_development_dependency 'pry', '~> 0.12.2'
   spec.add_development_dependency 'rake', '~> 12.3.2'
   spec.add_development_dependency 'rspec', '~> 3.8.0'
-  spec.add_development_dependency 'rubocop', '~> 0.61.1'
+  spec.add_development_dependency 'rubocop', '~> 0.71.0'
   spec.add_development_dependency 'rubocop-rspec', '~> 1.30.1'
   spec.add_development_dependency 'simplecov', '~> 0.16.1'
   spec.add_development_dependency 'simplecov-rcov', '~> 0.2.3'

--- a/spec/lib/nano_rpc/node_spec.rb
+++ b/spec/lib/nano_rpc/node_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe NanoRpc::Node do
   describe 'proxy methods' do
     let(:expected_proxy_methods) do
       %i[
+        active_difficulty
         available_supply
         block
         block_account
@@ -27,6 +28,7 @@ RSpec.describe NanoRpc::Node do
         bootstrap_status
         chain
         confirmation_active
+        confirmation_height_currently_processing
         confirmation_history
         confirmation_info
         confirmation_quorum

--- a/spec/lib/nano_rpc/node_spec.rb
+++ b/spec/lib/nano_rpc/node_spec.rb
@@ -17,6 +17,8 @@ RSpec.describe NanoRpc::Node do
         block_count
         block_count_type
         block_create
+        block_hash
+        block_info
         blocks
         blocks_info
         bootstrap
@@ -62,6 +64,7 @@ RSpec.describe NanoRpc::Node do
         unchecked_clear
         unchecked_get
         unchecked_keys
+        unopened
         uptime
         version
         wallet_create


### PR DESCRIPTION
Leave unmerged until Nano v19 is released.

Bump to v0.26.